### PR TITLE
setup: three.js assets and infrastructure fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ bun.lockb
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Three.js cloned repo (assets only)
+assets/threejs-repo

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-router-dom": "^6.26.1",
     "react-toastify": "^10.0.5",
     "tailwind-merge": "^2.5.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "three": "^0.167.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
@@ -55,7 +56,6 @@
     "postcss": "^8.4.41",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.9",
-    "three": "^0.167.1",
     "typescript": "^5.5.4",
     "vite": "^5.4.0"
   }


### PR DESCRIPTION
## Summary
- Cloned three.js repo (shallow) into `assets/threejs-repo/` for access to textures, models, and fonts
- Added `assets/threejs-repo/` to `.gitignore`
- Moved `three` from `devDependencies` to `dependencies` (it's used at runtime)

## Test plan
- [ ] Verify `npm run build` succeeds
- [ ] Verify `assets/threejs-repo/` is not tracked by git