### PR TITLE
fix: route existing implementations and quick fixes

### DIFF
--- a/src/components/data-structures/QueueDataStructure.tsx
+++ b/src/components/data-structures/QueueDataStructure.tsx
@@ -95,13 +95,13 @@ const QueueDataStructure: React.FC = () => {
             onClick={enqueue}
             className='bg-blue-500 text-white px-4 py-2 rounded mr-2'
           >
-            Push
+            Enqueue
           </button>
           <button
             onClick={dequeue}
             className='bg-red-500 text-white px-4 py-2 rounded'
           >
-            Pop
+            Dequeue
           </button>
         </div>
       </div>

--- a/src/helpers/contsant.ts
+++ b/src/helpers/contsant.ts
@@ -1,7 +1,7 @@
 export const dataStructuresComponentLinkList: componentLinkTT[] = [
   // Basic Data Structures
   {
-    color: 'red',
+    color: 'green',
     name: 'Array',
     path: '',
     tooltip: '',
@@ -289,11 +289,11 @@ export const dataStructuresComponentLinkList: componentLinkTT[] = [
     link: 'http://kuldeepahlawat.in',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'K-d Tree',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'ds-kd-tree',
   },
   {
     color: 'red',
@@ -497,32 +497,32 @@ export const algorithmsCompoentLinkList: componentLinkTT[] = [
     link: 'algo-selection-sort',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'Insertion Sort',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-insertion-sort',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'Merge Sort',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-merge-sort',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'Quick Sort',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-quick-sort',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'Heap Sort',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-heap-sort',
   },
   {
     color: 'red',
@@ -532,11 +532,11 @@ export const algorithmsCompoentLinkList: componentLinkTT[] = [
     link: 'http://kuldeepahlawat.in',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'Counting Sort',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-counting-sort',
   },
   {
     color: 'red',
@@ -548,18 +548,18 @@ export const algorithmsCompoentLinkList: componentLinkTT[] = [
 
   // Searching Algorithms
   {
-    color: 'red',
+    color: 'green',
     name: 'Linear Search',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-linear-search',
   },
   {
-    color: 'red',
+    color: 'green',
     name: 'Binary Search',
     path: '',
     tooltip: '',
-    link: 'http://kuldeepahlawat.in',
+    link: 'algo-binary-search',
   },
   {
     color: 'red',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,6 +20,11 @@ const BinaryTreeDataStructure = lazy(
   () => import('@/components/data-structures/BinaryTreeDataStructure')
 );
 
+// More Data Structures
+const KDTreeDataStructure = lazy(
+  () => import('@/components/data-structures/KDTreeDataStructure')
+);
+
 // Algorithms
 const BfsAlgorithmCircus = lazy(
   () => import('@/components/algorithms/BfsAlgorithmCircus')
@@ -32,6 +37,27 @@ const BubbleSortCircus = lazy(
 );
 const SelectionSortAlgorithmCircus = lazy(
   () => import('@/components/algorithms/SelectionSortAlgorithmCircus')
+);
+const InsertionSortCircus = lazy(
+  () => import('@/components/algorithms/InsertionSortCircus')
+);
+const MergeSortCircus = lazy(
+  () => import('@/components/algorithms/MergeSortCircus')
+);
+const QuickSortCircus = lazy(
+  () => import('@/components/algorithms/QuickSortCircus')
+);
+const HeapSortCircus = lazy(
+  () => import('@/components/algorithms/HeapSortCircus')
+);
+const CountingSortCircus = lazy(
+  () => import('@/components/algorithms/CountingSortCircus')
+);
+const BinarySearchCircus = lazy(
+  () => import('@/components/algorithms/BinarySearchCircus')
+);
+const LinearSearchCircus = lazy(
+  () => import('@/components/algorithms/LinearSearchCircus')
 );
 
 // Pages
@@ -82,6 +108,10 @@ const routes: RouteObject[] = [
         path: 'ds-binary-tree',
         element: withSuspense(BinaryTreeDataStructure),
       },
+      {
+        path: 'ds-kd-tree',
+        element: withSuspense(KDTreeDataStructure),
+      },
 
       // Algorithms routes
       {
@@ -103,6 +133,34 @@ const routes: RouteObject[] = [
       {
         path: 'algo-selection-sort',
         element: withSuspense(SelectionSortAlgorithmCircus),
+      },
+      {
+        path: 'algo-insertion-sort',
+        element: withSuspense(InsertionSortCircus),
+      },
+      {
+        path: 'algo-merge-sort',
+        element: withSuspense(MergeSortCircus),
+      },
+      {
+        path: 'algo-quick-sort',
+        element: withSuspense(QuickSortCircus),
+      },
+      {
+        path: 'algo-heap-sort',
+        element: withSuspense(HeapSortCircus),
+      },
+      {
+        path: 'algo-counting-sort',
+        element: withSuspense(CountingSortCircus),
+      },
+      {
+        path: 'algo-binary-search',
+        element: withSuspense(BinarySearchCircus),
+      },
+      {
+        path: 'algo-linear-search',
+        element: withSuspense(LinearSearchCircus),
       },
 
       // Catch-all route for 404


### PR DESCRIPTION
## Summary
- Added routes for 7 existing algorithm components (Insertion Sort, Merge Sort, Quick Sort, Heap Sort, Counting Sort, Binary Search, Linear Search)
- Added route for KD-Tree data structure
- Updated constants to mark these as green/available with proper route paths
- Marked Array DS as green (was red despite being routed)
- Fixed Queue DS button labels from Push/Pop to Enqueue/Dequeue

## Test plan
- [ ] Navigate to each new algorithm route and verify visualization loads
- [ ] Check dashboards show green indicators for newly routed items
- [ ] Verify Queue buttons show correct labels