### PR TITLE
feat: add Problems route with Two Sum visualization

### DIFF
--- a/src/components/RootLayout.tsx
+++ b/src/components/RootLayout.tsx
@@ -32,6 +32,11 @@ const RootLayout: React.FC<LayoutProps> = ({ children }) => {
       return 'from-blue-50 to-blue-100';
     } else if (location.pathname.startsWith('/ds-')) {
       return 'from-purple-50 to-purple-100';
+    } else if (
+      location.pathname === '/problems' ||
+      location.pathname.startsWith('/problem-')
+    ) {
+      return 'from-emerald-50 to-teal-100';
     } else if (location.pathname === '/algorithms') {
       return 'from-blue-50 to-blue-100';
     } else if (location.pathname === '/datastructure') {
@@ -94,6 +99,20 @@ const RootLayout: React.FC<LayoutProps> = ({ children }) => {
                   }
                 >
                   Algorithms
+                </NavLink>
+              </li>
+              <li>
+                <NavLink
+                  to={'/problems'}
+                  className={({ isActive }) =>
+                    `px-4 py-2 rounded-md transition-all duration-300 ${
+                      isActive
+                        ? 'bg-gradient-to-r from-emerald-500 to-teal-600 text-white shadow-md'
+                        : 'hover:bg-emerald-100 text-gray-700 hover:text-emerald-700 border border-transparent hover:border-emerald-200'
+                    }`
+                  }
+                >
+                  Problems
                 </NavLink>
               </li>
             </ul>

--- a/src/components/problems/TwoSumProblem.tsx
+++ b/src/components/problems/TwoSumProblem.tsx
@@ -1,0 +1,485 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Algorithm3DPreviewer } from '../../lib/algorithm3DPreviewer';
+import * as THREE from 'three';
+
+type Approach = 'brute-force' | 'hash-map';
+
+const TwoSumProblem: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const viewerRef = useRef<Algorithm3DPreviewer | null>(null);
+  const [nums, setNums] = useState<number[]>([2, 7, 11, 15]);
+  const [target, setTarget] = useState(9);
+  const [result, setResult] = useState<number[] | null>(null);
+  const [approach, setApproach] = useState<Approach>('brute-force');
+  const [highlightIndices, setHighlightIndices] = useState<number[]>([]);
+  const [hashMap, setHashMap] = useState<Map<number, number>>(new Map());
+  const [message, setMessage] = useState('');
+  const [isSolving, setIsSolving] = useState(false);
+  const [numsInput, setNumsInput] = useState('2,7,11,15');
+  const [step, setStep] = useState('');
+  const [comparisons, setComparisons] = useState(0);
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      viewerRef.current = new Algorithm3DPreviewer(canvasRef.current);
+      updateVisualization();
+    }
+    return () => {
+      viewerRef.current?.disposeCircus();
+    };
+  }, []);
+
+  useEffect(() => {
+    updateVisualization();
+  }, [nums, highlightIndices, hashMap, result]);
+
+  const updateVisualization = () => {
+    if (!viewerRef.current) return;
+    viewerRef.current.disposeSceneChildren();
+
+    const group = new THREE.Group();
+
+    // Draw array elements
+    nums.forEach((value, index) => {
+      const isHighlighted = highlightIndices.includes(index);
+      const isResult =
+        result !== null && (index === result[0] || index === result[1]);
+
+      let color = 0x4287f5; // blue default
+      if (isResult) color = 0x00cc44; // green for result
+      else if (isHighlighted) color = 0xff4444; // red for current comparison
+
+      const geometry = new THREE.BoxGeometry(1.2, 1.2, 1.2);
+      const material = new THREE.MeshStandardMaterial({ color });
+      const cube = new THREE.Mesh(geometry, material);
+      cube.position.x = index * 1.6;
+      group.add(cube);
+
+      // Value label
+      const canvas = document.createElement('canvas');
+      canvas.width = 128;
+      canvas.height = 64;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.fillStyle = 'white';
+        ctx.font = 'bold 48px Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(value.toString(), 64, 32);
+      }
+      const texture = new THREE.CanvasTexture(canvas);
+      const labelMat = new THREE.MeshBasicMaterial({
+        map: texture,
+        transparent: true,
+      });
+      const label = new THREE.Mesh(
+        new THREE.PlaneGeometry(1, 0.5),
+        labelMat
+      );
+      label.position.set(index * 1.6, 0.9, 0);
+      group.add(label);
+
+      // Index label
+      const idxCanvas = document.createElement('canvas');
+      idxCanvas.width = 128;
+      idxCanvas.height = 64;
+      const idxCtx = idxCanvas.getContext('2d');
+      if (idxCtx) {
+        idxCtx.fillStyle = '#aaa';
+        idxCtx.font = '32px Arial';
+        idxCtx.textAlign = 'center';
+        idxCtx.textBaseline = 'middle';
+        idxCtx.fillText(`[${index}]`, 64, 32);
+      }
+      const idxTexture = new THREE.CanvasTexture(idxCanvas);
+      const idxMat = new THREE.MeshBasicMaterial({
+        map: idxTexture,
+        transparent: true,
+      });
+      const idxLabel = new THREE.Mesh(
+        new THREE.PlaneGeometry(0.6, 0.3),
+        idxMat
+      );
+      idxLabel.position.set(index * 1.6, -0.9, 0);
+      group.add(idxLabel);
+    });
+
+    // Draw hash map visualization (below array)
+    if (approach === 'hash-map' && hashMap.size > 0) {
+      const mapGroup = new THREE.Group();
+      let col = 0;
+      hashMap.forEach((idx, key) => {
+        const boxGeo = new THREE.BoxGeometry(1, 0.6, 0.6);
+        const boxMat = new THREE.MeshStandardMaterial({ color: 0xf59e0b });
+        const box = new THREE.Mesh(boxGeo, boxMat);
+        box.position.set(col * 1.6, -2.5, 0);
+        mapGroup.add(box);
+
+        // key->idx label
+        const c = document.createElement('canvas');
+        c.width = 128;
+        c.height = 64;
+        const cx = c.getContext('2d');
+        if (cx) {
+          cx.fillStyle = 'white';
+          cx.font = 'bold 28px Arial';
+          cx.textAlign = 'center';
+          cx.textBaseline = 'middle';
+          cx.fillText(`${key}→${idx}`, 64, 32);
+        }
+        const t = new THREE.CanvasTexture(c);
+        const m = new THREE.MeshBasicMaterial({ map: t, transparent: true });
+        const l = new THREE.Mesh(new THREE.PlaneGeometry(0.9, 0.45), m);
+        l.position.set(col * 1.6, -2.5, 0.31);
+        mapGroup.add(l);
+        col++;
+      });
+
+      // "HashMap" title label
+      const titleCanvas = document.createElement('canvas');
+      titleCanvas.width = 256;
+      titleCanvas.height = 64;
+      const titleCtx = titleCanvas.getContext('2d');
+      if (titleCtx) {
+        titleCtx.fillStyle = '#f59e0b';
+        titleCtx.font = 'bold 32px Arial';
+        titleCtx.textAlign = 'center';
+        titleCtx.textBaseline = 'middle';
+        titleCtx.fillText('HashMap {val → idx}', 128, 32);
+      }
+      const titleTex = new THREE.CanvasTexture(titleCanvas);
+      const titleMat = new THREE.MeshBasicMaterial({
+        map: titleTex,
+        transparent: true,
+      });
+      const titleLabel = new THREE.Mesh(
+        new THREE.PlaneGeometry(2.5, 0.5),
+        titleMat
+      );
+      titleLabel.position.set(
+        ((hashMap.size - 1) * 1.6) / 2,
+        -1.8,
+        0
+      );
+      mapGroup.add(titleLabel);
+
+      mapGroup.position.x = -((nums.length - 1) * 1.6) / 2;
+      group.add(mapGroup);
+    }
+
+    // Target label at top
+    const targetCanvas = document.createElement('canvas');
+    targetCanvas.width = 256;
+    targetCanvas.height = 64;
+    const targetCtx = targetCanvas.getContext('2d');
+    if (targetCtx) {
+      targetCtx.fillStyle = '#10b981';
+      targetCtx.font = 'bold 36px Arial';
+      targetCtx.textAlign = 'center';
+      targetCtx.textBaseline = 'middle';
+      targetCtx.fillText(`Target: ${target}`, 128, 32);
+    }
+    const targetTex = new THREE.CanvasTexture(targetCanvas);
+    const targetMat = new THREE.MeshBasicMaterial({
+      map: targetTex,
+      transparent: true,
+    });
+    const targetLabel = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 0.5),
+      targetMat
+    );
+    targetLabel.position.set(0, 2.2, 0);
+    group.add(targetLabel);
+
+    group.position.x = -((nums.length - 1) * 1.6) / 2;
+    viewerRef.current.scene.add(group);
+    viewerRef.current.enableRender();
+  };
+
+  const solveBruteForce = async () => {
+    if (isSolving) return;
+    setIsSolving(true);
+    setResult(null);
+    setHashMap(new Map());
+    setComparisons(0);
+    let count = 0;
+
+    for (let i = 0; i < nums.length; i++) {
+      for (let j = i + 1; j < nums.length; j++) {
+        count++;
+        setComparisons(count);
+        setHighlightIndices([i, j]);
+        setStep(
+          `Checking: nums[${i}] + nums[${j}] = ${nums[i]} + ${nums[j]} = ${nums[i] + nums[j]}`
+        );
+        await new Promise((r) => setTimeout(r, 600));
+
+        if (nums[i] + nums[j] === target) {
+          setResult([i, j]);
+          setHighlightIndices([]);
+          setMessage(
+            `Found! nums[${i}] + nums[${j}] = ${nums[i]} + ${nums[j]} = ${target}`
+          );
+          setStep('');
+          setIsSolving(false);
+          return;
+        }
+      }
+    }
+    setHighlightIndices([]);
+    setMessage('No solution found');
+    setStep('');
+    setIsSolving(false);
+  };
+
+  const solveHashMap = async () => {
+    if (isSolving) return;
+    setIsSolving(true);
+    setResult(null);
+    const map = new Map<number, number>();
+    setHashMap(new Map());
+    setComparisons(0);
+    let count = 0;
+
+    for (let i = 0; i < nums.length; i++) {
+      count++;
+      setComparisons(count);
+      const complement = target - nums[i];
+      setHighlightIndices([i]);
+      setStep(
+        `Looking for complement: ${target} - ${nums[i]} = ${complement}`
+      );
+      await new Promise((r) => setTimeout(r, 800));
+
+      if (map.has(complement)) {
+        const j = map.get(complement)!;
+        setResult([j, i]);
+        setHighlightIndices([]);
+        setMessage(
+          `Found! nums[${j}] + nums[${i}] = ${nums[j]} + ${nums[i]} = ${target}`
+        );
+        setStep('');
+        setIsSolving(false);
+        return;
+      }
+
+      map.set(nums[i], i);
+      setHashMap(new Map(map));
+      setStep(`Added ${nums[i]} → index ${i} to HashMap`);
+      await new Promise((r) => setTimeout(r, 400));
+    }
+    setHighlightIndices([]);
+    setMessage('No solution found');
+    setStep('');
+    setIsSolving(false);
+  };
+
+  const solve = () => {
+    if (approach === 'brute-force') solveBruteForce();
+    else solveHashMap();
+  };
+
+  const reset = () => {
+    setResult(null);
+    setHighlightIndices([]);
+    setHashMap(new Map());
+    setMessage('');
+    setStep('');
+    setComparisons(0);
+  };
+
+  const applyInput = () => {
+    const parsed = numsInput
+      .split(',')
+      .map((s) => parseInt(s.trim()))
+      .filter((n) => !isNaN(n));
+    if (parsed.length >= 2) {
+      setNums(parsed);
+      reset();
+    }
+  };
+
+  return (
+    <div className="relative w-full h-screen overflow-hidden">
+      <canvas ref={canvasRef} className="w-full h-full" />
+
+      {/* Left Panel - Problem + Controls */}
+      <div className="absolute top-4 left-4 bg-white bg-opacity-95 p-4 rounded-lg shadow-lg max-w-sm max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="bg-green-100 text-green-700 text-xs font-bold px-2 py-1 rounded">
+            Easy
+          </span>
+          <span className="bg-gray-100 text-gray-600 text-xs px-2 py-1 rounded">
+            Array
+          </span>
+          <span className="bg-gray-100 text-gray-600 text-xs px-2 py-1 rounded">
+            Hash Table
+          </span>
+        </div>
+        <h2 className="text-xl font-bold mb-2">1. Two Sum</h2>
+        <p className="text-sm text-gray-600 mb-3">
+          Given an array of integers <code className="bg-gray-100 px-1 rounded">nums</code> and
+          an integer <code className="bg-gray-100 px-1 rounded">target</code>, return indices of
+          the two numbers such that they add up to target.
+        </p>
+
+        {/* Input */}
+        <div className="space-y-2 mb-3">
+          <div>
+            <label className="text-xs font-semibold text-gray-500">Array (comma-separated)</label>
+            <div className="flex gap-1">
+              <input
+                type="text"
+                value={numsInput}
+                onChange={(e) => setNumsInput(e.target.value)}
+                className="border rounded px-2 py-1 text-sm flex-1"
+                disabled={isSolving}
+              />
+              <button
+                onClick={applyInput}
+                className="bg-gray-200 px-2 py-1 rounded text-sm"
+                disabled={isSolving}
+              >
+                Set
+              </button>
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-semibold text-gray-500">Target</label>
+            <input
+              type="number"
+              value={target}
+              onChange={(e) => {
+                setTarget(parseInt(e.target.value) || 0);
+                reset();
+              }}
+              className="border rounded px-2 py-1 text-sm w-full"
+              disabled={isSolving}
+            />
+          </div>
+        </div>
+
+        {/* Approach Selection */}
+        <div className="mb-3">
+          <label className="text-xs font-semibold text-gray-500 block mb-1">
+            Approach
+          </label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                setApproach('brute-force');
+                reset();
+              }}
+              className={`flex-1 px-2 py-1 rounded text-sm border ${
+                approach === 'brute-force'
+                  ? 'bg-red-500 text-white border-red-500'
+                  : 'border-gray-300'
+              }`}
+              disabled={isSolving}
+            >
+              Brute Force
+            </button>
+            <button
+              onClick={() => {
+                setApproach('hash-map');
+                reset();
+              }}
+              className={`flex-1 px-2 py-1 rounded text-sm border ${
+                approach === 'hash-map'
+                  ? 'bg-amber-500 text-white border-amber-500'
+                  : 'border-gray-300'
+              }`}
+              disabled={isSolving}
+            >
+              Hash Map
+            </button>
+          </div>
+        </div>
+
+        {/* Solve / Reset */}
+        <div className="flex gap-2 mb-3">
+          <button
+            onClick={solve}
+            className="flex-1 bg-emerald-500 text-white px-3 py-2 rounded text-sm font-semibold"
+            disabled={isSolving}
+          >
+            {isSolving ? 'Solving...' : 'Solve'}
+          </button>
+          <button
+            onClick={reset}
+            className="bg-gray-300 px-3 py-2 rounded text-sm"
+            disabled={isSolving}
+          >
+            Reset
+          </button>
+        </div>
+
+        {/* Step display */}
+        {step && (
+          <div className="mb-2 p-2 bg-yellow-50 border border-yellow-200 rounded text-xs">
+            {step}
+          </div>
+        )}
+
+        {/* Result */}
+        {message && (
+          <div className="mb-2 p-2 bg-emerald-50 border border-emerald-200 rounded text-sm text-emerald-800 font-semibold">
+            {message}
+          </div>
+        )}
+
+        {result && (
+          <div className="mb-2 p-2 bg-blue-50 rounded text-sm">
+            <strong>Output:</strong> [{result.join(', ')}]
+          </div>
+        )}
+
+        {/* Stats */}
+        <div className="text-xs text-gray-500 space-y-1">
+          <div>
+            <strong>Comparisons:</strong> {comparisons}
+          </div>
+          <div>
+            <strong>Complexity:</strong>{' '}
+            {approach === 'brute-force' ? (
+              <span>
+                Time O(n<sup>2</sup>), Space O(1)
+              </span>
+            ) : (
+              <span>Time O(n), Space O(n)</span>
+            )}
+          </div>
+        </div>
+
+        {/* Examples */}
+        <div className="mt-3 border-t pt-2">
+          <p className="text-xs font-semibold text-gray-500 mb-1">Examples:</p>
+          <div className="space-y-1">
+            {[
+              { nums: '2,7,11,15', target: 9 },
+              { nums: '3,2,4', target: 6 },
+              { nums: '3,3', target: 6 },
+            ].map((ex, i) => (
+              <button
+                key={i}
+                onClick={() => {
+                  setNumsInput(ex.nums);
+                  setTarget(ex.target);
+                  const parsed = ex.nums.split(',').map(Number);
+                  setNums(parsed);
+                  reset();
+                }}
+                className="block w-full text-left text-xs p-1 rounded hover:bg-gray-100 border border-gray-100"
+                disabled={isSolving}
+              >
+                nums=[{ex.nums}], target={ex.target}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TwoSumProblem;

--- a/src/helpers/contsant.ts
+++ b/src/helpers/contsant.ts
@@ -1,3 +1,5 @@
+import { componentLinkTT, problemLinkTT } from '@/types/contantTypes';
+
 export const dataStructuresComponentLinkList: componentLinkTT[] = [
   // Basic Data Structures
   {
@@ -932,5 +934,20 @@ export const algorithmsCompoentLinkList: componentLinkTT[] = [
     path: '',
     tooltip: '',
     link: 'http://kuldeepahlawat.in',
+  },
+];
+
+export const problemsLinkList: problemLinkTT[] = [
+  // Array Problems
+  {
+    color: 'green',
+    number: 1,
+    name: 'Two Sum',
+    difficulty: 'Easy',
+    level: 'Junior',
+    topics: ['Array', 'Hash Table'],
+    tooltip:
+      'Given an array and a target, return indices of two numbers that add up to target.',
+    link: 'problem-two-sum',
   },
 ];

--- a/src/pages/ProblemsDashboard.tsx
+++ b/src/pages/ProblemsDashboard.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { problemsLinkList } from '../helpers/contsant';
+import { FaCircle } from 'react-icons/fa6';
+import { problemLinkTT } from '@/types/contantTypes';
+
+import { FaCode, FaLightbulb } from 'react-icons/fa';
+
+const getDifficultyColor = (difficulty: string) => {
+  switch (difficulty) {
+    case 'Easy':
+      return 'bg-green-100 text-green-700';
+    case 'Medium':
+      return 'bg-yellow-100 text-yellow-700';
+    case 'Hard':
+      return 'bg-red-100 text-red-700';
+    default:
+      return 'bg-gray-100 text-gray-700';
+  }
+};
+
+const groupByTopic = (items: problemLinkTT[]) => {
+  const grouped: Record<string, problemLinkTT[]> = {};
+
+  items.forEach((item) => {
+    const topic = item.topics[0] || 'Miscellaneous';
+    if (!grouped[topic]) {
+      grouped[topic] = [];
+    }
+    grouped[topic].push(item);
+  });
+
+  return grouped;
+};
+
+const ProblemsDashboard = () => {
+  const groupedProblems = groupByTopic(problemsLinkList);
+
+  return (
+    <div className='w-full px-4 py-6 text-gray-800'>
+      <div className='max-w-7xl mx-auto'>
+        <div className='mb-10'>
+          <h1 className='text-4xl md:text-5xl font-bold mb-4 text-transparent bg-clip-text bg-gradient-to-r from-emerald-600 to-teal-600'>
+            Problems
+          </h1>
+          <p className='text-gray-600 text-lg'>
+            Visualize classic coding problems and their solutions step-by-step
+            with 3D animations.
+          </p>
+
+          <Card className='mt-6 border border-emerald-100 bg-white shadow-sm'>
+            <CardContent className='p-4'>
+              <div className='flex gap-6 items-center flex-wrap'>
+                <div className='flex gap-2 items-center'>
+                  <FaCircle className='text-green-500 text-sm' />
+                  <span className='font-medium text-gray-700'>Available</span>
+                </div>
+                <div className='flex gap-2 items-center'>
+                  <FaCircle className='text-red-500 text-sm' />
+                  <span className='font-medium text-gray-700'>Coming Soon</span>
+                </div>
+                <div className='text-sm text-gray-500'>
+                  Difficulty:{' '}
+                  <span className='bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs'>
+                    Easy
+                  </span>{' '}
+                  <span className='bg-yellow-100 text-yellow-700 px-2 py-0.5 rounded text-xs'>
+                    Medium
+                  </span>{' '}
+                  <span className='bg-red-100 text-red-700 px-2 py-0.5 rounded text-xs'>
+                    Hard
+                  </span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {Object.entries(groupedProblems).map(([topic, problems]) => (
+          <section key={topic} className='mb-16'>
+            <div className='flex items-center gap-3 mb-6'>
+              <div className='p-3 rounded-full bg-white shadow-sm border border-emerald-100'>
+                <FaCode className='text-emerald-600' />
+              </div>
+              <h2 className='text-2xl md:text-3xl font-bold text-gray-800'>
+                {topic}
+              </h2>
+            </div>
+
+            <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6'>
+              {problems.map((problem, index) => (
+                <Link
+                  key={`${problem.name}-${index}`}
+                  to={`/${problem.link}`}
+                  className={`block transform transition-all duration-300 hover:scale-105 ${
+                    problem.color === 'red'
+                      ? 'pointer-events-none opacity-70'
+                      : ''
+                  }`}
+                >
+                  <Card
+                    className={`h-full border transition-all duration-300 hover:shadow-md overflow-hidden
+                    ${
+                      problem.color === 'green'
+                        ? 'bg-white border-emerald-200 hover:border-emerald-300'
+                        : 'bg-white border-gray-200'
+                    } relative group`}
+                  >
+                    <CardContent className='p-6 relative z-10'>
+                      <div className='flex items-center gap-3 mb-3'>
+                        <span className='relative flex h-3 w-3'>
+                          <span
+                            className='animate-ping absolute inline-flex h-full w-full rounded-full opacity-75'
+                            style={{
+                              backgroundColor:
+                                problem.color === 'green'
+                                  ? '#10b981'
+                                  : '#ef4444',
+                            }}
+                          ></span>
+                          <span
+                            className='relative inline-flex rounded-full h-3 w-3'
+                            style={{
+                              backgroundColor:
+                                problem.color === 'green'
+                                  ? '#10b981'
+                                  : '#ef4444',
+                            }}
+                          ></span>
+                        </span>
+                        <span className='font-bold text-lg text-gray-800'>
+                          {problem.number}. {problem.name}
+                        </span>
+                      </div>
+
+                      {/* Difficulty + Level */}
+                      <div className='flex gap-2 mb-2 flex-wrap'>
+                        <span
+                          className={`text-xs font-bold px-2 py-0.5 rounded ${getDifficultyColor(problem.difficulty)}`}
+                        >
+                          {problem.difficulty}
+                        </span>
+                        {problem.level && (
+                          <span className='text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-700'>
+                            {problem.level}
+                          </span>
+                        )}
+                      </div>
+
+                      {/* Topics */}
+                      <div className='flex gap-1 flex-wrap mb-3'>
+                        {problem.topics.map((topic) => (
+                          <span
+                            key={topic}
+                            className='text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-600'
+                          >
+                            {topic}
+                          </span>
+                        ))}
+                      </div>
+
+                      {problem.tooltip && (
+                        <p className='text-sm text-gray-500 line-clamp-2'>
+                          {problem.tooltip}
+                        </p>
+                      )}
+
+                      <div className='mt-4 pt-3 border-t border-gray-200 flex justify-between items-center'>
+                        <span className='text-xs text-gray-500'>
+                          {problem.color === 'green'
+                            ? 'Interactive Visualization'
+                            : 'Coming Soon'}
+                        </span>
+                        <FaLightbulb className='text-amber-400 text-sm' />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProblemsDashboard;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -130,12 +130,18 @@ const TopologicalSortCircus = lazy(
   () => import('@/components/algorithms/TopologicalSortCircus')
 );
 
+// Problems
+const TwoSumProblem = lazy(
+  () => import('@/components/problems/TwoSumProblem')
+);
+
 // Pages
 const Home = lazy(() => import('../pages/Home'));
 const DataStructuresDashboard = lazy(
   () => import('../pages/DataStructuresDashboard')
 );
 const AlgorithmsDashboard = lazy(() => import('../pages/AlgorithmsDashboard'));
+const ProblemsDashboard = lazy(() => import('../pages/ProblemsDashboard'));
 
 // Wrap component with Suspense
 const withSuspense = (Component: React.ComponentType) => (
@@ -319,6 +325,16 @@ const routes: RouteObject[] = [
       {
         path: 'algo-topological-sort',
         element: withSuspense(TopologicalSortCircus),
+      },
+
+      // Problems routes
+      {
+        path: 'problems',
+        element: withSuspense(ProblemsDashboard),
+      },
+      {
+        path: 'problem-two-sum',
+        element: withSuspense(TwoSumProblem),
       },
 
       // Catch-all route for 404

--- a/src/types/contantTypes.ts
+++ b/src/types/contantTypes.ts
@@ -5,3 +5,14 @@ export type componentLinkTT = {
   link: string;
   path: string;
 };
+
+export type problemLinkTT = {
+  color: string;
+  number: number;
+  name: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  level: string;
+  topics: string[];
+  tooltip: string;
+  link: string;
+};


### PR DESCRIPTION
## Summary
- New `/problems` route with Problems Dashboard page
- New `problemLinkTT` type with difficulty, level, topics fields
- Navigation updated with "Problems" link (emerald/teal theme)
- **Two Sum** problem visualization with:
  - Brute Force approach (O(n^2)) - animated pair comparison
  - Hash Map approach (O(n)) - animated complement lookup with HashMap visualization
  - 3D array visualization with color-coded elements
  - Problem description, examples, difficulty badge, topic tags
  - Step-by-step animation showing current operation
  - Comparison counter and complexity display

## Test plan
- [ ] Navigate to /problems - dashboard shows Two Sum card with Easy badge and Array/Hash Table topics
- [ ] Click Two Sum card -> /problem-two-sum loads 3D visualization
- [ ] Test Brute Force approach - watch pair-by-pair comparison animation
- [ ] Test Hash Map approach - watch complement lookup with HashMap building
- [ ] Try all 3 example inputs
- [ ] Try custom input